### PR TITLE
Wear os module

### DIFF
--- a/.github/workflows/wearos.yml
+++ b/.github/workflows/wearos.yml
@@ -120,8 +120,7 @@ jobs:
           keyStorePassword: "${{secrets.RELEASE_KEY_PASSWORD}}"
           releaseDirectory: WearOs/app/build/outputs/bundle/prodRelease
           signingKeyBase64: "${{secrets.WEAR_OS_SIGNING_KEY}}"
-       env:
-          SIGNED_RELEASE_FILES: WearOs/app/build/outputs/bundle/prodRelease
+
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/wearos.yml
+++ b/.github/workflows/wearos.yml
@@ -120,7 +120,7 @@ jobs:
           keyStorePassword: "${{secrets.RELEASE_KEY_PASSWORD}}"
           releaseDirectory: WearOs/app/build/outputs/bundle/prodRelease
           signingKeyBase64: "${{secrets.WEAR_OS_SIGNING_KEY}}"
-      - env:
+       env:
           SIGNED_RELEASE_FILES: WearOs/app/build/outputs/bundle/prodRelease
 
       - uses: actions/upload-artifact@v1


### PR DESCRIPTION
WEAR_OS_WORKFLOW syntax fix. NO_CI to avoid mindLamp workflow run.