### PR TITLE
WEAR_OS_WORKFLOW:  Could not get unknown property 'release' for Signi…

### DIFF
--- a/WearOs/app/build.gradle
+++ b/WearOs/app/build.gradle
@@ -25,7 +25,7 @@ android {
     }
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+          //  signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             debuggable = false


### PR DESCRIPTION
WEAR_OS_WORKFLOW:  Could not get unknown property 'release' for SigningConfig issue fix. NO_CI to avoid mindLamp workflow run.