### PR TITLE
Workflow fix : Android Gradle plugin requires Java 11 to run. You are…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,7 @@ jobs:
       -
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       -
         env:
           FIREBASE_CONFIG: "${{secrets.GOOGLE_SERVICES_JSON}}"


### PR DESCRIPTION
Workflow fix : Android Gradle plugin requires Java 11 to run. You are currently using Java 1.8.