### PR TITLE
Security hardening 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "digital.lamp.mindlamp"
         minSdkVersion minimum_sdk
         targetSdkVersion target_sdk
-        versionCode 1039
-        versionName "2025.11.24"
+        versionCode 1042
+        versionName "2.1.0"
         buildConfigField 'boolean', 'DO_LOG', 'true'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk.abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "digital.lamp.mindlamp"
         minSdkVersion minimum_sdk
         targetSdkVersion target_sdk
-        versionCode 1042
-        versionName "2.1.0"
+        versionCode 1039
+        versionName "2025.11.24"
         buildConfigField 'boolean', 'DO_LOG', 'true'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk.abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
 
     <application
         android:name=".app.App"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"

--- a/app/src/main/java/digital/lamp/mindlamp/HomeActivity.kt
+++ b/app/src/main/java/digital/lamp/mindlamp/HomeActivity.kt
@@ -1070,8 +1070,6 @@ class HomeActivity : AppCompatActivity() {
         //Updating current user token
         retrieveCurrentToken()
 
-        //Setting User Attributes for Firebase
-        firebaseAnalytics.setUserProperty("user_token", oLoginResponse.authorizationToken)
         invokeSensorSpecData()
         initialCallForActivityStreak()
     }
@@ -1267,8 +1265,6 @@ class HomeActivity : AppCompatActivity() {
                         LampLog.printStackTrace(e)
                     }
                 }
-                //Setting User Attributes for Firebase
-                firebaseAnalytics.setUserProperty("user_fcm_token", token)
             }
 
         }

--- a/app/src/main/java/digital/lamp/mindlamp/HomeActivity.kt
+++ b/app/src/main/java/digital/lamp/mindlamp/HomeActivity.kt
@@ -562,7 +562,7 @@ class HomeActivity : AppCompatActivity() {
     private fun initializePrivacyPolicyWebview(){
         binding.webView.clearCache(true)
         binding.webView.clearHistory()
-        WebView.setWebContentsDebuggingEnabled(true)
+        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
         binding.webView.settings.javaScriptEnabled = true
         binding.webView.settings.mediaPlaybackRequiresUserGesture = false
         binding.webView.settings.domStorageEnabled = true
@@ -592,7 +592,7 @@ class HomeActivity : AppCompatActivity() {
     private fun initializeWebview() {
         binding.webView.clearCache(true)
         binding.webView.clearHistory()
-        WebView.setWebContentsDebuggingEnabled(true)
+        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
         binding.webView.settings.javaScriptEnabled = true
         binding.webView.settings.mediaPlaybackRequiresUserGesture = false
         binding.webView.settings.domStorageEnabled = true

--- a/app/src/main/java/digital/lamp/mindlamp/HomeActivity.kt
+++ b/app/src/main/java/digital/lamp/mindlamp/HomeActivity.kt
@@ -613,7 +613,6 @@ class HomeActivity : AppCompatActivity() {
                         "http://"
                     )
             )
-            Log.e("url","$url")
             binding.webView.loadUrl(url)
 
         } else {
@@ -970,7 +969,6 @@ class HomeActivity : AppCompatActivity() {
         /** Show a toast from the web page  */
         @JavascriptInterface
         fun postMessage(jsonString: String) {
-            Log.e(TAG, " : $jsonString")
             try {
                 val loginResponse = Gson().fromJson(jsonString, LoginResponse::class.java)
                 if (loginResponse != null && loginResponse.authorizationToken != null && !loginResponse.deleteCache) {
@@ -1361,8 +1359,6 @@ class HomeActivity : AppCompatActivity() {
                     AppState.session.token + ":" + AppState.session.serverAddress.removePrefix("https://")
                         .removePrefix("http://")
                 )
-
-            DebugLogs.writeToFile("URL : $oSurveyUrl")
 
             val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             manager.cancel(notificationId)

--- a/app/src/main/java/digital/lamp/mindlamp/NotificationActionActivity.kt
+++ b/app/src/main/java/digital/lamp/mindlamp/NotificationActionActivity.kt
@@ -38,8 +38,6 @@ class NotificationActionActivity : AppCompatActivity() {
                 .removePrefix("http://")
         )
 
-        DebugLogs.writeToFile("URL : $oSurveyUrl")
-
         val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         manager.cancel(notificationId)
 

--- a/app/src/main/java/digital/lamp/mindlamp/NotificationActivity.kt
+++ b/app/src/main/java/digital/lamp/mindlamp/NotificationActivity.kt
@@ -42,7 +42,6 @@ class NotificationActivity : AppCompatActivity() {
                 .removePrefix("http://")
         )
 
-        DebugLogs.writeToFile("URL : $oSurveyUrl")
         binding.customWebview.clearCache(true)
         binding.customWebview.clearHistory()
         binding.customWebview.settings.javaScriptEnabled = true


### PR DESCRIPTION
Cleanup pass on the Android client to remove a few unnecessary credential / identifier exposure surfaces and tighten build-time settings around debugging and OS backups. No functional changes for end users. 

## Changes
  - Removed several verbose logging statements that were emitting sensitive values                               
  - Restricted WebView remote debugging to debug builds only                      
  - Disabled OS-level auto-backup of app data                                                                    
  - Removed telemetry user-properties that included sensitive identifiers

## Risk: Low 
All changes are removals or debug-flag gates — no new code paths, no changed runtime behavior. The higher-risk accumulated changes on master since the last release (foreground service / sensor pipeline) have been separately validated via QA APK against the prod server, with passive data collection confirmed working over a multi-day window.                                                                                             

## Notes                                
  - Two version-bump commits cancel out, made the change before I noticed that the release workflow handles versioning automatically
  - One user-visible change: new installs will no longer be included in Android's system auto-backup; existing users keep their existing backups until reinstall