### PR TITLE
fix: prevent onMessageReceived crash on malformed actions payload

### DIFF
--- a/app/src/main/java/digital/lamp/mindlamp/notification/LampFirebaseMessagingService.kt
+++ b/app/src/main/java/digital/lamp/mindlamp/notification/LampFirebaseMessagingService.kt
@@ -47,13 +47,19 @@ class LampFirebaseMessagingService : FirebaseMessagingService() {
         // them to disk in debug builds to avoid leaking that data into LampLog.txt in release.
         if (BuildConfig.DEBUG) DebugLogs.writeToFile(remoteMessage.data.toString())
         val gson = Gson()
-        var actionList: List<ActionData> = listOf()
-        if (remoteMessage.data["actions"] != null)
-            actionList = gson.fromJson(
-                remoteMessage.data["actions"],
-                object : TypeToken<List<ActionData?>?>() {}.type
-            ) as List<ActionData>
-
+        val actionList: List<ActionData> = remoteMessage.data["actions"]
+            ?.takeIf { it.isNotBlank() }
+            ?.let { raw ->
+                try {
+                    gson.fromJson<List<ActionData>>(
+                        raw,
+                        object : TypeToken<List<ActionData>>() {}.type
+                    ) ?: emptyList()
+                } catch (e: Exception) {
+                    LampLog.e(TAG, "Failed to parse FCM actions payload", e)
+                    emptyList()
+                }
+            } ?: emptyList()
         //Notification with page and action Button
         if (remoteMessage.data["page"] != null && remoteMessage.data["page"]?.isNotEmpty() == true && actionList.isNotEmpty()) {
             LampNotificationManager.notificationWithActionButton(this, remoteMessage, actionList)


### PR DESCRIPTION
Fixes #166 

onMessageReceived parsed the FCM actions payload with no error handling and an unchecked cast, so a malformed/invalid actions value threw out of the handler — dropping the notification (and risking a crash loop on a repeatedly bad payload).

This guards the parse with a try/catch, removes the unchecked cast, handles null/blank input, and falls back to an empty list (logging the failure). Well-formed payloads are unaffected; notifications without valid actions now degrade gracefully instead of crashing.